### PR TITLE
Make :content mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,6 @@ This will create a file `/etc/facter/facts.d/env.txt` containing:
 
     environment=production
 
-If the `$target` is not specified, it defaults to the name of the resource.
+* `content is mandatory. It can not be empty string or whitespace.
+* `$target` is optional. It defaults to the name of the resource.
+* `ensure` is optional. It defaults to `present`.

--- a/lib/puppet/type/fact.rb
+++ b/lib/puppet/type/fact.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:fact) do
   newproperty(:content) do
     desc "The content of the fact"
     validate do |value|
-      raise ArgumentError, "Content cannot be whitespace" if value.match(/^\s+$/)
+      fail("Content cannot be whitespace") if value.match(/^\s+$/)
     end
   end
 

--- a/lib/puppet/type/fact.rb
+++ b/lib/puppet/type/fact.rb
@@ -19,8 +19,9 @@ Puppet::Type.newtype(:fact) do
 
   newproperty(:content) do
     desc "The content of the fact"
+    defaultto ''
     validate do |value|
-      fail("Content cannot be whitespace") if value.match(/^\s+$/)
+      fail("Content cannot be empty or whitespace") if value.match(/^\s*$/)
     end
   end
 

--- a/spec/unit/type/fact_spec.rb
+++ b/spec/unit/type/fact_spec.rb
@@ -19,6 +19,14 @@ describe Puppet::Type.type(:fact) do
   end
 
   context "when validating content" do
+    it "should be mandatory" do
+      expect { described_class.new(:name => "environment") }.to raise_error
+    end
+
+    it "should reject empty string" do
+      expect { described_class.new(:name => "environment", :content => "") }.to raise_error
+    end
+
     it "should reject only whitespace" do
       expect { described_class.new(:name => "environment", :content => " ") }.to raise_error
     end
@@ -30,7 +38,7 @@ describe Puppet::Type.type(:fact) do
   end
 
   context "when validating target" do
-    resource = described_class.new(:name => "environment")
+    resource = described_class.new(:name => "environment", :content => "production")
 
     it "can be optional" do
       expect { resource }.to_not raise_error
@@ -41,7 +49,7 @@ describe Puppet::Type.type(:fact) do
     end
 
     it "should accept specified values" do
-      described_class.new(:name => "environment", :target => "env").should(:target).should == "env"
+      described_class.new(:name => "environment", :content => "production", :target => "env").should(:target).should == "env"
     end
   end
 


### PR DESCRIPTION
If the content is empty or whitespace, facter returns the following error:

`Fact file /etc/facter/facts.d/$fact.txt was parsed but returned an empty
data set`

This commit defaults it to whitespace, which is invalid value
