### PR TITLE
Convert the content to a string always

### DIFF
--- a/lib/puppet/provider/fact/fact.rb
+++ b/lib/puppet/provider/fact/fact.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:fact).provide(:fact) do
     basename = File.basename(filename, ".txt")
 
     if provider.ensure == :present and provider.target == basename
-      result = "#{provider.name}=#{provider.content}\n"
+      result = "#{provider.name}=#{provider.content.to_s}\n"
     end
 
     return result


### PR DESCRIPTION
In case we want to pass a boolean (eg fact { 'something': content => true }) we
should convert that to a string always
